### PR TITLE
Add Theme Quickswitcher Script & Fix scripts broken by revamp

### DIFF
--- a/scripts/breeding-lock.user.js
+++ b/scripts/breeding-lock.user.js
@@ -8,7 +8,7 @@
 // @match       https://*.flightrising.com/lair*
 // @match       https://*.flightrising.com/den*
 // @grant       none
-// @version     1.0.0
+// @version     1.0.1
 // @license     MIT
 // @icon        https://www.google.com/s2/favicons?sz=64&domain=flightrising.com
 // ==/UserScript==
@@ -19,16 +19,14 @@
 const F = 1,
       M = 0,
       NBS_ASSETS = {
-        can_breed : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAqNQTFRFAAAAhIB1hIB1hIB1hYF2hYF2hoN2hIB1hIB1hIB1hYB1kYyB5dvR+vPq+fDp49fPiIV1hIB1hIB1hoV2iol21c3Gq6GX5NjI+fDm+vTr69/QsqaXiod3hIB1hIB1hYF2h4V4+vfz9fHqn5KIzb+o4tTB5tbF18iztKiYycO7hYF2hIB1hIB1iIh57+rltaqiqp+Txridw7mXt7CXopiO+fby6+fgiYd2hIB1j4p86uLc1M7GtKmhsKacyMC57Ofiiod3hIB1hIB1hIB1z8fA8Ovm8+/o5NzWr6ifhn9zhIB15dzW8uzn9vXv9/Xwoa+TR2cuI0wGPl0kWGVEf31whIB1hYF27OnixcChvriRwcGhvMWwJE0IKVANPlkmLFQPIUwFWGZEhIB1hYF2v7mn1sau7d7NuKyPy8i3/fz3W3JELU8QfXtcnot6bm9VJksLMVMYhIB1s6eX38265dPAyrmmq6SU+PTtz8nBPFcfRl8ow6yexq2dy7qva21ZZGxRhIB1h4N4p5uTy7Wm79nHvKiXrKWc+vTv9vDra3VUNFcVM1gUbXRNbXRMd4FcTV04PlYoHEEBhIB1gX5xwbSxkIN5q5eKjH502tTP9e/q7ebjHkgBKWMBK2cBKmQBJVkBLGoBJl0BHkcBgnxzopmTzMS+rqWf3tjT9/Hs8+zpHkoBTmUt0r+ySmMvJFkB7eXig310ysG73NPM2tHL4trU5NvV39fRH0oBK2oBZHZF4tLKLUQVJFgBhIB1dGxl2M/Jz8a/zsW+H0sBLm8BLm4BJ1UHbmFeIU0BJlwBhIB1hX92cWljvbSu4tnT5d3XH0wBL3EBKWIBI1MBGz0CdW9mHhMOWE5KcmpkaWBaIkcGI1UBIU8BHEUB////lZSLiYh/l4CBreMNlgAAAOF0Uk5TAILe7/r76g585/T9/v///+h1e97k//////////WVJbz8////////////9VB28////////////+S1+v////////xuGeT//////7hR///////////wQoHy/////////////qdv9v//////////////+ddZ////////////////+JxT6P/////////////////7wWku5P///////////////////9j//////////////wfN/////////////+7/YNj/////////8/j/Bnzh/////////9BscMzp4vv//+kCFhgKeaEyHwAAAM9JREFUeJxjZMACGKEUBPxEEuRghIH3cEEhRgR4DBWUY0QGVyGCOoyMnxn4YIInIYIWjIzPGRikwHqBuvaDBJ2AvDtQt6gC2dtBgl47PRgZr4CEdCEGrAEKhoJZx4GCVhDB+UDBJAhzJ4MH1KoJQMHCT/wg5uowmP2NQMEGRnSQz8gwCVXkHzNjHNCdi8GcJbGMn/+DDPoMFlwPV/VMGkg8BQsy7AVK8zH+Z4LI3IQIngSxX0iChf6fZ4AIMjBcgeqHhKYKNOQZ7gKFFGDRAQCrgSoVqjiWggAAAABJRU5ErkJggg==",
-        cant_breed : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAqZQTFRFAAAAbl1Qbl1Qbl1Qb15Rb15RcF9Rbl1Qbl1Qbl1Qb11QeWZYv5+P0bGg0K+fvZyOcWFQbl1Qbl1QcGFRc2RRspWIj3Vnvp2J0K+d0bGhxKKOlXlnc2JRbl1Qbl1Qb15RcWFS0bSmza+ghWpdq4tzvZqEwJyHs5F7lnpoqI6Ab15Rbl1Qbl1QcWNTx6qdl3xvjnRlpYZro4dnmYBnh29h0LOmxKiZcmJRbl1Qd2RVw6SXsZaIlntuk3lrp4x/xaibc2JRbl1Qbl1Qbl1QrZGDyKudy66fvqCSknptcFxPbl1Qv6CSyqyezbKk0LKkonRqczQqYBwPay0jZj01bVpNbl1Qb15RxaqbpIxun4ZjoYxusId9YR0PYiASZysmZCMUYBwNZj42bl1Qb15Rn4dys5B3xqGMmn1iqZF907epdkE2YSEUfVFEhWVUcEhAXx8RYikfbl1QupV/v5qDqYdyj3dlz7GirZKEZSofbzAko31spX5rqYd3YicdYSIYbl1QcV9Si3FlqYRyx56InXpnkHhr0bGkza+hdUlBayYYayYZfEY9hVBIaSMWZh8SWhISbl1QbFxNoYN5eF9Tj25edVxPtpqOza6gxqebYRcPfCcFfykGfScIciAMgyoJfSgFdSQDYBcObVpPh29lqo+CkXhtuZ2Qzq+iy6yfYhcPfCYIdTQqsop6bzMqcCEGxqebbVtPqYyAuJqMtpiLvZ+Rvp+SupyPYxgPgioGficKgEM5vZmKVB4ZbyAGbl1QYU9FtJeKrZCDrI+CZBgPhywIhiwIbSAPXEdAZRoLdCMDbl1Qb1xRXkxEnoN3vZ6Qv6GTZRkQiS4IeycEbB4IVBIRYlFGGQ4KSTkzX01EWEY+XhgTbR4MZxsLXRQQ1bqvfGxfcmNXfl1YSou4DwAAAOJ0Uk5TAILe7/r76g585/T9/v///+h1e97k//////////WVJbz8////////////9VB28////////////+S1+v////////xuGeT//////7hR///////////wQoHy/////////////qdv9v//////////////+dBZ///////////////94FPo/////////////////u9pLuT/////////////////////2P///////////////wfN///////////////u/2DY//////////P4/wZ84f/////////QbHDM6eL7///pAhYYCleBUjwAAADKSURBVHicY2TAAhihFAT8RBLkYISB93BBIUYEeAwVlGNEBlchgjqMjJ8Z+GCCJyGCFoyMzxkYpMB6gbr2gwSdgLw7ULeoAtnbQYJeOz0YGa+AhHQhBqwBCoaCWceBglYQwflAwSQIcyeDB9SqCUDBwk87wkGaQmH2NwEF65FdCfZvISPDBEZ0EA905yIwa2kM4yd+EOMTWHA9qrrHYEGGfYwgRf+ZIILXIYKnQOznUmCh/2cZIIIMDFdhloMDThka8gz3gELysOgAABUsKBV+DcHKAAAAAElFTkSuQmCC",
+        can_breed : `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAqNQTFRFAAAAhIB1hIB1hIB1hYF2hYF2hoN2hIB1hIB1hIB1hYB1kYyB5dvR+vPq+fDp49fPiIV1hIB1hIB1hoV2iol21c3Gq6GX5NjI+fDm+vTr69/QsqaXiod3hIB1hIB1hYF2h4V4+vfz9fHqn5KIzb+o4tTB5tbF18iztKiYycO7hYF2hIB1hIB1iIh57+rltaqiqp+Txridw7mXt7CXopiO+fby6+fgiYd2hIB1j4p86uLc1M7GtKmhsKacyMC57Ofiiod3hIB1hIB1hIB1z8fA8Ovm8+/o5NzWr6ifhn9zhIB15dzW8uzn9vXv9/Xwoa+TR2cuI0wGPl0kWGVEf31whIB1hYF27OnixcChvriRwcGhvMWwJE0IKVANPlkmLFQPIUwFWGZEhIB1hYF2v7mn1sau7d7NuKyPy8i3/fz3W3JELU8QfXtcnot6bm9VJksLMVMYhIB1s6eX38265dPAyrmmq6SU+PTtz8nBPFcfRl8ow6yexq2dy7qva21ZZGxRhIB1h4N4p5uTy7Wm79nHvKiXrKWc+vTv9vDra3VUNFcVM1gUbXRNbXRMd4FcTV04PlYoHEEBhIB1gX5xwbSxkIN5q5eKjH502tTP9e/q7ebjHkgBKWMBK2cBKmQBJVkBLGoBJl0BHkcBgnxzopmTzMS+rqWf3tjT9/Hs8+zpHkoBTmUt0r+ySmMvJFkB7eXig310ysG73NPM2tHL4trU5NvV39fRH0oBK2oBZHZF4tLKLUQVJFgBhIB1dGxl2M/Jz8a/zsW+H0sBLm8BLm4BJ1UHbmFeIU0BJlwBhIB1hX92cWljvbSu4tnT5d3XH0wBL3EBKWIBI1MBGz0CdW9mHhMOWE5KcmpkaWBaIkcGI1UBIU8BHEUB////lZSLiYh/l4CBreMNlgAAAOF0Uk5TAILe7/r76g585/T9/v///+h1e97k//////////WVJbz8////////////9VB28////////////+S1+v////////xuGeT//////7hR///////////wQoHy/////////////qdv9v//////////////+ddZ////////////////+JxT6P/////////////////7wWku5P///////////////////9j//////////////wfN/////////////+7/YNj/////////8/j/Bnzh/////////9BscMzp4vv//+kCFhgKeaEyHwAAAM9JREFUeJxjZMACGKEUBPxEEuRghIH3cEEhRgR4DBWUY0QGVyGCOoyMnxn4YIInIYIWjIzPGRikwHqBuvaDBJ2AvDtQt6gC2dtBgl47PRgZr4CEdCEGrAEKhoJZx4GCVhDB+UDBJAhzJ4MH1KoJQMHCT/wg5uowmP2NQMEGRnSQz8gwCVXkHzNjHNCdi8GcJbGMn/+DDPoMFlwPV/VMGkg8BQsy7AVK8zH+Z4LI3IQIngSxX0iChf6fZ4AIMjBcgeqHhKYKNOQZ7gKFFGDRAQCrgSoVqjiWggAAAABJRU5ErkJggg==`,
+        cant_breed : `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAqZQTFRFAAAAbl1Qbl1Qbl1Qb15Rb15RcF9Rbl1Qbl1Qbl1Qb11QeWZYv5+P0bGg0K+fvZyOcWFQbl1Qbl1QcGFRc2RRspWIj3Vnvp2J0K+d0bGhxKKOlXlnc2JRbl1Qbl1Qb15RcWFS0bSmza+ghWpdq4tzvZqEwJyHs5F7lnpoqI6Ab15Rbl1Qbl1QcWNTx6qdl3xvjnRlpYZro4dnmYBnh29h0LOmxKiZcmJRbl1Qd2RVw6SXsZaIlntuk3lrp4x/xaibc2JRbl1Qbl1Qbl1QrZGDyKudy66fvqCSknptcFxPbl1Qv6CSyqyezbKk0LKkonRqczQqYBwPay0jZj01bVpNbl1Qb15RxaqbpIxun4ZjoYxusId9YR0PYiASZysmZCMUYBwNZj42bl1Qb15Rn4dys5B3xqGMmn1iqZF907epdkE2YSEUfVFEhWVUcEhAXx8RYikfbl1QupV/v5qDqYdyj3dlz7GirZKEZSofbzAko31spX5rqYd3YicdYSIYbl1QcV9Si3FlqYRyx56InXpnkHhr0bGkza+hdUlBayYYayYZfEY9hVBIaSMWZh8SWhISbl1QbFxNoYN5eF9Tj25edVxPtpqOza6gxqebYRcPfCcFfykGfScIciAMgyoJfSgFdSQDYBcObVpPh29lqo+CkXhtuZ2Qzq+iy6yfYhcPfCYIdTQqsop6bzMqcCEGxqebbVtPqYyAuJqMtpiLvZ+Rvp+SupyPYxgPgioGficKgEM5vZmKVB4ZbyAGbl1QYU9FtJeKrZCDrI+CZBgPhywIhiwIbSAPXEdAZRoLdCMDbl1Qb1xRXkxEnoN3vZ6Qv6GTZRkQiS4IeycEbB4IVBIRYlFGGQ4KSTkzX01EWEY+XhgTbR4MZxsLXRQQ1bqvfGxfcmNXfl1YSou4DwAAAOJ0Uk5TAILe7/r76g585/T9/v///+h1e97k//////////WVJbz8////////////9VB28////////////+S1+v////////xuGeT//////7hR///////////wQoHy/////////////qdv9v//////////////+dBZ///////////////94FPo/////////////////u9pLuT/////////////////////2P///////////////wfN///////////////u/2DY//////////P4/wZ84f/////////QbHDM6eL7///pAhYYCleBUjwAAADKSURBVHicY2TAAhihFAT8RBLkYISB93BBIUYEeAwVlGNEBlchgjqMjJ8Z+GCCJyGCFoyMzxkYpMB6gbr2gwSdgLw7ULeoAtnbQYJeOz0YGa+AhHQhBqwBCoaCWceBglYQwflAwSQIcyeDB9SqCUDBwk87wkGaQmH2NwEF65FdCfZvISPDBEZ0EA905yIwa2kM4yd+EOMTWHA9qrrHYEGGfYwgRf+ZIILXIYKnQOznUmCh/2cZIIIMDFdhloMDThka8gz3gELysOgAABUsKBV+DcHKAAAAAElFTkSuQmCC`,
         settings : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC8AAAAvCAYAAABzJ5OsAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAACJtJREFUeJzNWvlXFFcW9pw5J/P3zUwyv2T+gJk5mYmJidqNIt1IIygoi8a4xGhcAkY5IwYTRI2Csoggm+zQGw1NL/RG043Anffd6ldWdVfRBTEk95yPrnr1qu5377vvvvuq2LfPQJqbyz6ocNr/7nLYbgrMVzjs2QqHjfYO9qTLYR+H/kpHyUfgY8SzQETnv4ibpveW7PYAH1e57a+mpJubm//kcpZUyRtuXLtEL3tf0MpKlDY23tJeSjaboVAoSH29z5mHaoTgB54F5LXEe7o795RsMent7tIZoCdebvtQXvR5PepNW1tbFI+GKbTo31NElhcpFY/pDAAv1QDBV52cIqZ8aOzrea52TiXie07aCOAhBfzYAKfdz5O48njJxzLG84kvB3y/K4wMUOeA0/4PEev22zh51d+jdpA37VZpYiVCa6sp2tzYoM3NTT5G268xQMpAf68k/8M+8ceNk5jIKpCE+N0t8fDSAmXW0qYTDwaERJ/dkE/k+IFnjrxbeN6Wwcnbt0o6jAQXRGfc6N0x0qmEQjIepztN16mi9BA5S77g42Ru6DPp1V1438e8IEjbuYUsu0/OYCnvbtod8Ug4ROUlX9KhT/+pQ0XpYV4zIKvJ+A6fr3CSIjkbkBedFyxA9ItHQ5TNrHFK3dra5Psba04w2Z/v/49KD+7XGfB1Q62agoH17Bo/w6oRlsgHFzxFAU/Pz83QxbNnmCR+x8eG6UXnL3T5fAP193YXeB/X3owOU131cSo58B+60Hia+l50ipFIUDgYEM/1msISeSvEU2LYe5930uH9/9KRwzlIIzwQ79prnb88oi6BfIOA+y23OR0qBpjrtUDeXQQeWk2l6Njhz6iyzC5IdeiIOGwHhCeTdOlcHY0Ov6b06iolhWdRr9g//0TX91VfN508XsrH9+40iecmtiHvtkjeb04+JmL0p/strHB8bIRcx2w6QggJv1jKh1+/omuXvqIy2+c8gR+3PxBtA2yU7HvKVUYeEXq1lQ4+n54cp/hK2FR3UfJL/nkBtymQqs7X17DC3ufPdMSry49S55MOuvP9dcPwgDEYDW3bqYpj5HXPccjVn3LxwsbOM4AF8nM5AwqBFAc5evBTarl9i25evayPa0G8VcQvjo98+V96+qidyWn7YLTqTlbo2h4+aKWm69/yMQxJJVYM9Rcn7zMmL4lDoOTWtct0uqpcJfCNyDDPnnSoOd0zP1dgHPDDre9EhunStWEha29r5eOOn+6zDujbMflF36xiQB7Ws1m+jskHcvmkkAKvXDjLx+65WU6DRqFTf9JFfp/H8BqAkYOsr2dyUfAOxcl7Z9gACQwhFiLEIl8PLNCD1pYCpVlhHOL2q7pT1N311JTc8aMHuXwwu/7s8UPWA33rIkOlErGcA2eLkw94p1XiWP3yJbQcFEP7o5riJBAm+K094WSYkTvhKKFoJGx6HaP2dn1dpxMODAinFifvmWLvx6PLfI4S9NyZk1R+5KCq4N7dZpqbmaIzIi1qlZoR0gLhNDM1YXjt7Okq1QnQd/Z0NQ2+6mMesRyfbckvCPKwMr2qFFrfX/vGUBEqxQWfl3weN81OT1IqlbREHmFx48qFgvbG2iqamhijpu+u6NqhHyILPwvkp3WWjo0MUZXzyLakpibe6BYgI/DqKzYmqDzb2+7R1Yvn+J62e3fJKzwu0yUAfdArJRYJWiDvnhShM81YCS+JlKVshDNra7wImRHDAoTCK78EkCg58IlYQSfo0c9tPGkxb0AORuNebV/ogT4I9IPHgmeyOHm/e5zjfiW8uCPPAyi+RkRZ4LR/oWv/uqGGesRq3Pmko+gztJ5/o/F8NBSwQH7+DVuZynn8btMNXbxiBZQyPzut1iUSWGRWohGuOrHCLonUOjs9RTe+vWiZuBYtzTdZFzJOUfK++THh/QlhqeL5gZc9POuRuyHIMljOH7W38dYRBuyGVDEg2yDLyWwTDfktkJ8T5OfHRexPUDIeoXxBVpAKRkSVKAUFG1Jgfv7fCVCBBhcDBTqTsQhzskB+lEMnHFT2jKjHEQpDA/3scdtn/1aVobZBOzYZ+IWY5XCrGOxXPL0pnJHNpCkB4sKR4FSUvHd2hL2fiIX53KgUMAKyDN4QYAR+DfmGmkrWmxX7WyQPCZ918qO8OYagkNI+HDso1OuoYfIVYwMCsULyvLgfo4qFbnRoUFSkDzllvux5oYRKXAkVCTjUAvlh8s6NqPEejUTUVxkovOTLKUirKBMkGWzjIF1PH6ttMDK0vMRlcD75MbEpMZNYZInDRAs4tCh5z8wQGwBLEXMQ+Tqj9NB+pdPWFv/0aKpHeA8yNPCSR0ubUvm5YgWty9VCV4WHIShBEA4ACOMcv7JNC0SEZfLS85isWo9hhYSgrNVmFtT4WPa1kkpEKbLs1+XofA/DSVYAXhbIvybP7BBPGEj+lm07DA8qMY97k/EwD7UEnCHnkephzXVzjLHXwauAvMtpS+Agk8nwBcQXrERulcONWK8RO/38N2AA2jGJLzTW8luwzFpKzJnR9wqOhlzM695Vuhy2SZyEc0MeWnKTe3pQCZ1cupSylk5zUSWJI+/nSzwaZE+9T4APeHGo6d8SF76fR2cg4J1kT0Kwp4TIzIHFKri0yJN3c3ODMunUb0IcXgcXKbr380ZfRlbCAdUAiXDw3btC/WikxBwZLgrvrqAQBx8pui8jum9Sve++SUVEIVRgwJKHJyKL8DiIB0QF6pkZzmEoD8O7xJDq8YimIAM/+U2qvr7+z/LD8UdyBuO1hFYQa/JB7xevDc6VNuiTMS4FvCRH8NV9zhSzt1pe7O3pMgyR30vUr4BKlqk2+QJua5CdEFuYxMoX8I09JQt90Av9ui/gDnuj4Rdwzf8e/O0P+r8HH5r/x4RuFMo+4Cwk0hH+60OMyPqekhX6+L9NhH7wMPuvj/8Dvs0LG+7msNEAAAAASUVORK5CYII="
       };
 
-// MAIN
 function runNoBreedScript() {
 
   console.log("[FR Breeding Lock Script] Active")
-
   // set up defaults on first run
   if(localStorage.getItem(`fr-do-not-breed-list`)  == null) {
     localStorage.setItem( `fr-do-not-breed-list`, `[]` );
@@ -50,7 +48,7 @@ function runNoBreedScript() {
     #nobreed-controls {
       position: absolute;
       top: 8px;
-      right: 40px;
+      right: 50px;
     }
     .nobreed-button {
       padding: 0;
@@ -178,18 +176,20 @@ function runNoBreedScript() {
     }
     .rmv-dragon {
       margin-right: 1em;
-      color: rgba(var(--error, 150, 0, 0),0.3);
-      background: rgba(var(--error, 150, 0, 0),0.1);
+      color: var(--text, #000);
+      background: rgba(150, 0, 0, 0.5);
+      opacity: 0.5;
       border: none;
       position: relative;
       cursor: pointer;
       font-weight: bold;
-      transition: 0.3s color;
+      transition: 0.3s opacity;
       padding: 0 0.3em;
       border-radius: 5px;
     }
     .rmv-dragon:hover {
-      color: rgba(var(--error, 150, 0, 0),1);
+      color: var(--text, #000);
+      opacity: 1;
     }
     .rmv-dragon.tipsy::after {
       font-weight: normal;
@@ -219,7 +219,7 @@ function runNoBreedScript() {
         settings_modal = createNoBreedScriptModal('settings', `Breeding Lock Script Settings`, modal_content,`--width: 350px;--left:-300px;`),
         settings_button = createNoBreedScriptButton('settings', `Breeding Lock Script Settings`, settings_modal, NBS_ASSETS.settings),
         container = document.createElement("div");
-    document.querySelector(`.inner-content`).before(container);
+    document.querySelector(`#fr-layout-tutorial-button`).before(container);
     container.id = `nobreed-controls`;
     container.append(settings_modal,settings_button);
 
@@ -249,7 +249,6 @@ function runNoBreedScript() {
       backup_zone.prepend(button);
     });
     backup_zone.querySelector("#backup-import").disabled = true;
-
     // dynamically enable import button based on whether or not textarea is empty
     ['change','keyup'].forEach(event => {
       backup_zone.querySelector("#data").addEventListener(event, function(e) {
@@ -271,9 +270,12 @@ function runNoBreedScript() {
       danger_zone.append(button);
     });
 
-  } else if (/open-nest/.test(window.location.href)) {
-    console.log("\t[FR Breeding Lock Script] On Breeding Page");
 
+
+  } else if (/open-nest/.test(window.location.href)) {
+        
+    console.log("\t[FR Breeding Lock Script] On Breeding Page");
+        
     // load and split our unbreedables into separate mom and dad lists
     let unbreedables = JSON.parse(localStorage.getItem(`fr-do-not-breed-list`)),
         remove = localStorage.getItem(`fr-do-not-breed-remove`),
@@ -287,6 +289,7 @@ function runNoBreedScript() {
     // we call the function to handle removing or disabling dragons that we don't want to breed.
     const observer_dad = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
+        //console.log(mutation.type, mutation.target.id, mutation.target.childNodes.length, mutation.target.attributes)
         if (mutation.type != "childList" && mutation.target.classList.contains("nest-picker") && mutation.target.disabled != true) {
           doDragonRemove(mutation.target,dads,remove);
         }
@@ -294,11 +297,20 @@ function runNoBreedScript() {
     });
     const observer_mom = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
+        //console.log(mutation.type, mutation.target.id, mutation.target.childNodes.length, mutation.target.attributes)
+        // whenever it gets re-disabled we can call this to remove newly added stuff
+
+        //console.log(`added: ${mutation.addedNodes.length} / removed: ${mutation.removedNodes.length}`)
+        // whenever our selector gets disabled we will call our remove function to re-remove stuff since it keeps requesting the list of valid dragons every time you change the dragon
         if (mutation.type != "childList" && mutation.target.classList.contains("nest-picker") && mutation.target.disabled != true) {
+          //console.log("\tin if:",mutation.type, mutation.target.id, mutation.target.attributes);
+          //let before = mutation.target.childNodes.length;
           doDragonRemove(mutation.target,moms,remove);
+          //console.log(`\t\tremove done: before remove: ${before} / after remove: ${mutation.target.childNodes.length}`) //high number is from \n's that aren't removed when node is removed
         }
       });
     });
+
     // start observing the parents of the selects
     observer_dad.observe(dad_info, {
       attributes: true,
@@ -312,8 +324,7 @@ function runNoBreedScript() {
     });
 
   } else if (/dragon/.test(window.location.href) && document.querySelector("#dragon-profile-owner-buttons") != null && document.querySelector(`.common-ui-button[data-tooltip-source="#button-breed-tooltip"]`) != null) {
-    console.log("\t[FR Breeding Lock Script] on dragon's profile");
-
+    // add our css
     applyBreedScriptCSS(`[data-toggle="on"] .off { display: none; }
     [data-toggle="off"] .on { display: none; }
     .breed-lock-icon { float: right; position: relative; cursor: pointer;}
@@ -330,9 +341,11 @@ function runNoBreedScript() {
     .hide { display: none !important }
     `);
 
+    console.log("\t[FR Breeding Lock Script] on dragon's profile");
+
     // get gender, id, and toggle button
     let header = document.querySelector("#dragon-profile-details-lineage > .dragon-profile-details-header"),
-        name = document.querySelector(".dragon-profile-header-name").innerText,
+        name = document.querySelector(`#dragon-profile-header h1.responsive-page-header-title`).innerText.replace(/#|\(|\)| |[0-9]|\n/g, ''),
         id = document.querySelector(".dragon-profile-header-number").innerText.substring(2, document.querySelector(".dragon-profile-header-number").innerText.length-1),
         gender = (document.querySelector(`.dragon-profile-icons img[alt~="Female"]`) != null) ? F : M,
         unbreedables = JSON.parse(localStorage.getItem(`fr-do-not-breed-list`)),
@@ -342,8 +355,7 @@ function runNoBreedScript() {
         breed_tooltip = document.querySelector("#button-breed-tooltip"),
         original_breeding_tooltip = breed_tooltip.cloneNode(true),
         started_disabled = (breed_button.classList.contains(`common-ui-button-disabled`)) ? true : false;
-    breed_tooltip.setAttribute("data-original-image",breed_button.querySelector(`img`).src);
-    original_breeding_tooltip.id = "button-breed-tooltip-original"; //make copy of original tooltip for toggling purposes
+    original_breeding_tooltip.id = "button-breed-tooltip-original"; // make copy of it for toggling purposes
     original_breeding_tooltip.classList = "hide";
     breed_tooltip.after(original_breeding_tooltip); // put after the original tooltip
 
@@ -354,9 +366,10 @@ function runNoBreedScript() {
     if (found != undefined) {
       breed_tooltip.innerHTML = `This dragon has been <strong>locked</strong> from breeding.`;
       breed_button.classList.add("common-ui-button-disabled");
+      breed_button.classList.add("theme-ui-1-disabled")
+      breed_button.classList.remove("theme-ui-1");
       breed_button.disabled = true;
       breed_button.href = '';
-      breed_button.querySelector(`img`).src = `/static/layout/profile/button-breed-disabled.png`;
     }
     // add our toggle breed lock button to the 'lineage' header
     toggle_button.innerHTML = `<img src="${NBS_ASSETS.cant_breed}" class="off" alt="This Dragon is Locked for Breeding"><img src="${NBS_ASSETS.can_breed}" class="on" alt="This Dragon is Unlocked For Breeding">`;
@@ -368,14 +381,15 @@ function runNoBreedScript() {
     toggle_button.addEventListener("click", function() { manageNoBreedScriptDragonStatus(name, id, gender, this, breed_tooltip, breed_button, started_disabled) });
     breed_button.addEventListener("click", function(event) {
       if (this.classList.contains(`common-ui-button-disabled`)) {
-          event.preventDefault(); // prevent us from clicking locked dragons' buttons
+          event.preventDefault(); // prevent us from clicking locked dragons' breed button
       }
     });
     header.append(toggle_button);
 
-  } else if ((/lair/.test(window.location.href) || /den/.test(window.location.href)) && document.querySelector("#lair-action-edit") != null) {
-    console.log("\t[FR Breeding Lock Script] In our lair or den.");
 
+
+  } else if ((/lair/.test(window.location.href) || /den/.test(window.location.href)) && document.querySelector("#lair-action-edit") != null) {
+    // add css
     applyBreedScriptCSS(`[data-toggle="on"] .off { display: none; }
     [data-toggle="off"] .on { display: none; }
     .breed-lock-icon {position:relative; font-size: 11px;}
@@ -393,12 +407,12 @@ function runNoBreedScript() {
     .tipsy:hover::after { display: block !important; }
     `);
 
+    console.log("\t[FR Breeding Lock Script] In our lair or den.");
     // get all dragons & our list of unbreedables
     let dragons = document.querySelectorAll(".lair-page-dragon"),
         unbreedables = JSON.parse(localStorage.getItem(`fr-do-not-breed-list`)),
         lair_management = localStorage.getItem(`fr-do-not-breed-lair-management`),
         toggle_button = document.createElement("span");
-    
     // set up base lair icon to copy and use    
     toggle_button.innerHTML = `<img src="${NBS_ASSETS.cant_breed}" class="off" alt="This Dragon is Locked for Breeding"><img src="${NBS_ASSETS.can_breed}" class="on" alt="This Dragon is Unlocked For Breeding">`;
     toggle_button.classList = `breed-lock-icon tipsy`;
@@ -406,7 +420,6 @@ function runNoBreedScript() {
     toggle_button.setAttribute("data-tipsy-off","This Dragon is Locked for Breeding");
     toggle_button.setAttribute("data-tipsy-on","This Dragon is Unlocked For Breeding");
     toggle_button.setAttribute("data-tipsy",toggle_button.getAttribute("data-tipsy-on"));
-
     // loop thru dragons, getting their info & checking if they're already locked or not
     dragons.forEach(dragon => {
       let url = dragon.querySelector("a").href.split("/"),
@@ -452,8 +465,9 @@ function manageNoBreedScriptDragonStatus(name, id, gender, button, breed_tooltip
     if (!skip) {
       breed_tooltip.innerHTML = `This dragon has been <strong>locked</strong> from breeding.`;
       breed_button.classList.add("common-ui-button-disabled");
+      breed_button.classList.add("theme-ui-1-disabled");
+      breed_button.classList.remove("theme-ui-1");
       breed_button.href = '';
-      breed_button.querySelector(`img`).src = `/static/layout/profile/button-breed-disabled.png`;
     }
     console.log(`\t[FR Breeding Lock Script] Added ${dragon.name} (#${dragon.id}) to unbreedable list.`)
   } else {
@@ -466,8 +480,8 @@ function manageNoBreedScriptDragonStatus(name, id, gender, button, breed_tooltip
       breed_tooltip.innerHTML = document.querySelector("#button-breed-tooltip-original").innerHTML;
       if (!started_disabled) {
         breed_button.classList.remove("common-ui-button-disabled");
-        breed_button.querySelector(`img`).src = breed_tooltip.getAttribute("data-original-image");
-        breed_button.href = breed_button.getAttribute("data-href");
+        breed_button.classList.remove("theme-ui-1-disabled");
+        breed_button.classList.add("theme-ui-1");
       }
     }
     console.log(`\t[FR Breeding Lock Script] Removed ${found.name} (#${found.id}) from unbreedable list.`)
@@ -680,8 +694,7 @@ function loadNoBreedScriptSettings() {
           backup_zone = settings_modal.querySelector("#settings-list #backup-zone"),
           exported_backup = backup_zone.querySelector("#data"),
           danger_zone = settings_modal.querySelector("#settings-list #danger-zone");
-
-  // refresh content each time we run this script
+  // refresh content of modal each time we run this function
   general.innerHTML = '';
   dragonlist_container.innerHTML = '<h4><img src="https://www1.flightrising.com/static/layout/lair/icons/male.png" alt="Male"> Males</h4><h4><img src="https://www1.flightrising.com/static/layout/lair/icons/female.png" alt="Female"> Females</h4><ul class="dragon-list" id="males"></ul><ul id="females" class="dragon-list"></ul>';
   exported_backup.value = '';

--- a/scripts/forum-and-bbcode-tweaks.user.js
+++ b/scripts/forum-and-bbcode-tweaks.user.js
@@ -8,7 +8,7 @@
 // @match       https://*.flightrising.com/forums*
 // @match       https://*.flightrising.com/msgs/*
 // @grant       none
-// @version     1.0.1
+// @version     1.0.2
 // @license     MIT
 // @icon        https://www.google.com/s2/favicons?sz=64&domain=flightrising.com
 // ==/UserScript==
@@ -122,6 +122,8 @@ function FBTinit() {
     repeat = true;
   }
 
+  appendCSS();
+
   if (window.location.href.match("flightrising.com/forums")) {
     let add_more_actions = localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-more-post-actions`),
         forum_search_link = localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-forum-search-link`);
@@ -130,209 +132,22 @@ function FBTinit() {
     if (add_more_actions == "true" || forum_search_link == "true") { morePostActions(document.querySelectorAll(".post .post-frame"), add_more_actions, forum_search_link); }
   }
   bbcodeButtons(textarea_to_affect, element_to_wait_for, repeat, recursive_condition_to_wait_for);
+  //userNotes();
 }
 
 // GENERAL FORUMS SETTINGS / THREAD TRACKER
 function loadSettingsAndThreadTracker() {
 
   // thread tracker gets added to pages of forums where forum control bar is present
-  if (document.querySelector("#forum-controls")) {
+  if (document.querySelector("#forum-controls") || document.querySelector("#forum-actions")) {
     console.log("\t[F&BT] ADD THREAD TRACKER BUTTON");
-    const head = document.head || document.getElementsByTagName('head')[0],
-      style = document.createElement('style');
-    let css = `
-    .bbcode-button {
-      padding: 0;
-      height: 47px;
-      width: 47px;
-      box-sizing: border-box;
-      position: relative;
-      z-index: 5;
-      cursor: pointer;
-    }
-    .bbcode-modal:not(.hide) + .bbcode-button.modal {
-      z-index: 11;
-    }
-    .bbcode-modal:not(.hide) + .bbcode-button.modal::before {
-      content: '';
-      position:fixed;
-      top: 0px;
-      left: 0px;
-      width: 100%;
-      height: 100%;
-      border: none;
-      background: rgba(0,0,0,0.5);
-      outline: none;
-      border: none;
-    }
-    .ui-modal-content {
-      position: relative;
-      border: 0;
-      padding: .5em 1em;
-      background: none;
-      overflow: auto;
-    }
-    .bbcode-modal {
-      position: absolute;
-      width: var(--width, 250px);
-      min-height: 200px;
-      z-index: 101;
-      top: 50px;
-      box-sizing: border-box;
-      left: var(--left, -50%);
-    }
-    .bbcode-modal .ui-widget-content h3:first-child {
-      margin-top: 0;
-    }
-    .bbcode-modal img {
-      vertical-align: middle;
-      border: 1px solid var(--borders, #ccc);
-      margin-left: 0.5em;
-    }
-    .bbcode-modal a {
-      color: var(--link, #731d08)
-    }
-    .check-list, .button-list {
-      display: grid;
-      text-align: left;
-      grid-gap: 0.5em;
-      margin: 0.8em 0 0.5em;
-    }
-    .col-2 {
-      grid-template-columns: 1fr 1fr;
-    }
-    .check-list label {
-      display: grid;
-      grid-template-columns: 25px auto;
-      align-items: center;
-    }
-    .button-list {
-      flex-wrap: wrap;
-    }
-    .threads {
-      margin: 10px 0 10px 5px;
-      max-height: 16em;
-      overflow: auto;
-      padding-right: 0.6em;
-    }
-    .threads li {
-      display: flex;
-      margin-bottom: 0.5em;
-    }
-    .threads li::before {
-      content: '•' / '';
-      margin-right: 5px;
-    }
-    .threads li i {
-      margin-left: auto;
-    }
-    .threads li > a, .threads li > i {
-      text-overflow: ellipsis;
-      display: inline-block;
-      overflow-x: hidden;
-      white-space: pre;
-      line-height: 1.3em;
-      max-width: 100%;
-    }
-    .threads.show-authors li > a {
-      max-width: 70%;
-    }
-    .threads.show-authors li > i {
-      max-width: 30%;
-    }
-    button.rmv-setting {
-      padding: 0.5em !important;
-      width: 100%;
-    }
-    .rmv-bookmark {
-      margin-left: auto;
-      color: rgba(var(--error, 150, 0, 0),0.3);
-      background: none;
-      border: none;
-      position: relative;
-      cursor: pointer;
-      font-weight: bold;
-      transition: 0.3s color;
-    }
-    .rmv-bookmark:hover {
-      color: rgba(var(--error, 150, 0, 0),1);
-    }
-    .rmv-bookmark.tipsy::after {
-      font-weight: normal;
-      left: unset;
-      right: 1em;
-      top: -0.3em;
-      min-width: 25px;
-    }
-    .threads.show-authors li > i + .rmv-bookmark {
-      margin-left: 0.4em
-    }
-    #backup-zone #data {
-      grid-column: 1 / 3;
-      resize: none;
-      height: 150px;
-      width: 100%;
-      font-size: 10px;
-      font-family: monospace;
-    }
-    .expand-setting {
-      cursor: pointer;
-      background: none;
-      border: none;
-      color: inherit;
-      font: inherit;
-      display: inline-flex;
-      justify-content: space-between;
-      width: 100%;
-    }
-    .expand-setting span {
-      margin-left: auto;
-    }
-    .expand {
-      max-height: 0px;
-      overflow: hidden;
-      transition: max-height 0.3s, opacity: 0.3s;
-    }
-    .expand.expanded {
-      max-height:500px;
-      opacity: 1;
-    }
-    .expander :is(.on,.off) {
-      pointer-events: none;
-    }
-    .post-action-quick-ping.tipsy::after { top: calc(100% + 6px); left: calc(50% - 40px); }
-    .post-action-quick-ping:hover::after, .post-action-quick-ping:focus::after { display: block; }
-    .thread-locked { pointer-events: none !important; user-select: none; opacity: 0.5; }
-    .tipsy::after {
-      content: attr(data-tipsy); min-width: 150px; max-width: 300px; height: auto; line-height: 120%;
-      font-size: 1rem; color: var(--text, #000); background: var(--tooltip-bg, #fff); border-radius: 10px;
-      font-size: inherit; position: absolute; border:1px solid var(--borders, #888);box-shadow:rgba(0, 0, 0, 0.5) 1px 1px 6px;
-      top: 112%; left: calc(50% - 100px); padding: 8px; box-sizing: border-box; z-index: 2;right:unset;bottom:unset;
-      text-align: left;
-      display: none;
-    }
-    .tipsy:hover::after { display: block !important; }
-    .bbcode-modal:not(.hide) + .bbcode-button.modal::after { display: none !important; }
-    .threads:empty::before { content: "No threads found."; display: block; font-style: italic; margin-bottom: 1.2em; }
-    .toggled[data-toggled="0"] .on { display: none; }
-    .toggled[data-toggled="1"] .off { display: none; }
-    .hide {
-      display: none !important;
-    }
-    `;
-    if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-more-post-actions`) == "true") {
-      css += `
-      .post-frame {
-        min-height: 330px;
-      }`;
-    }
-
-    head.appendChild(style);
-    style.type = 'text/css';
-    style.appendChild(document.createTextNode(css));
 
     var forum_controls = document.querySelector("#forum-controls"),
         subscribe_button = document.querySelector("span:has(#toggle-subscribe)");
+
+    if (forum_controls == null) {
+      forum_controls = document.querySelector("#forum-actions");
+    }
 
     // create thread tracker modal + button
     var threads_modal = createForumControlsModal("threads",`Thread Tracker`,`<div class="common-dialog-section" id="bbcode-threads"><div id="bookmarked"><h3>Bookmarked:</h3><ul class="threads"></ul></div><div id="starred"></div></div>`,`--left: -80%; width: 425px;`),
@@ -348,7 +163,7 @@ function loadSettingsAndThreadTracker() {
     threads_button.before(threads_modal); // its associated modal goes directly before it
 
     // ADD SETTINGS BUTTON - only applies to forum landing page
-    if (document.querySelector(`#forum-header[data-level="forum"]`)) {
+    if (document.querySelectorAll(`.breadcrumbs a`).length == 1) {
       console.log("\t[F&BT] ON FORUM INDEX, ADD SETTINGS BUTTON");
       var settings_modal =  createForumControlsModal("settings", `Forum & BBCode Tweaks Script Settings`, `<div class="common-dialog-section" id="settings-list"><h3>Thread Tracker:</h3><div id="tracker-settings" class="check-list"></div><h3>Miscellaneous:</h3><div id="misc-settings" class="check-list"></div><h3>Additional BBCode Buttons:</h3><div id="tags" class="check-list col-2"></div><h3><button class="expand-setting expander toggled" data-target="#backup-zone" data-toggled="0">Backups: <span class="off">☰</span><span class="on">✕</span></h3><div id="backup-zone" class="button-list col-2 expand"></div><h3><button class="expand-setting expander toggled" data-target="#danger-zone" data-toggled="0">Reset: <span class="off">☰</span><span class="on">✕</span></h3><div id="danger-zone" class="button-list col-2 expand"></div></div>`,`--width: 350px;`),
         settings_button =  createForumControlsButton("settings", `Tap this button to adjust Forum & BBCode Tweaks Script Settings.`, settings_modal, ASSETS.settings);
@@ -672,7 +487,7 @@ function loadTrackedThreads() {
 function threadWatcher(event, type) {
   var url_splice = window.location.href.split(".com/")[1],
       subsplice = url_splice.split("/"),
-      author = (subsplice.length == 3 || (subsplice.length > 3 && subsplice[3] == 1)) ? document.querySelector(".post-author-username") : "",
+      author = (subsplice.length == 3 || (subsplice.length > 3 && subsplice[3] == 1)) ? document.querySelector(".post-author-username-hidden a") : "",
       topic = document.querySelector("#topic-header strong").innerText,
       topic_id = subsplice[2],
       thread_link = `/${subsplice[0]}/${subsplice[1]}/${subsplice[2]}`,
@@ -735,7 +550,7 @@ function quickPing(posts) {
     // loop thru posts, skipping blocked posts or our own posts
     posts.forEach((post) => {
         //skip our own posts or blocked posts
-        if (post.querySelector(".post-author-username") == null) {
+        if (post.querySelector(".post-author-username-hidden a") == null) {
             //console.log("\t\t[F&BT] Quick Ping: Blocked post, skipping");
         } else if (post.querySelector(".post-author-actions") == null) {
             //console.log("\t\t[F&BT] Quick Ping: It's your post, skipping");
@@ -748,7 +563,7 @@ function quickPing(posts) {
             var copiedPingButton = pingButton.cloneNode(true);
 
             // set data-name & title
-            copiedPingButton.setAttribute("data-name",post.querySelector(".post-author-username").innerText);
+            copiedPingButton.setAttribute("data-name",post.querySelector(".post-author-username-hidden a").innerText);
             copiedPingButton.setAttribute("data-tipsy",`Click to ping ${copiedPingButton.getAttribute("data-name")} in a quick reply.`);
 
             // add the button to the page and insert it into the post header after the quote button
@@ -777,17 +592,22 @@ function quickPing(posts) {
     console.log("\t[F&BT] Quick Ping: Done!");
   }
 }
+
+// ----------------------------------------------- //
+//               MORE POST ACTIONS                 //
+// ----------------------------------------------- //
+
 function morePostActions(posts, add_more_actions, forum_search_link) {
   posts.forEach(post => {
-    if (post.querySelector(".post-author-username") != null) {
+    if (post.querySelector(".post-author-username-hidden a") != null) {
 
       let stats = post.querySelector(".post-author-stats"),
-          author = post.querySelector(".post-author-username").innerText;
+          author = post.querySelector(".post-author-username-hidden a").innerText;
 
       // optional begin a forum search link
       if (forum_search_link == "true") {
         let post_count_stat = stats.querySelector(`.post-author-stat[data-stat="post"]`);
-        post_count_stat.innerHTML = `<a href="https://${window.location.hostname}/search/forums?poster=${author}&sort=recent&submit=Search%2BForums" class="post-stat-count" title="Recent Posts by ${author}">${post_count_stat.querySelector(".post-stat-count").innerText}</a>`;
+        post_count_stat.innerHTML = `<a href="https://${window.location.hostname}/search/forums?poster=${author}&sort=recent&submit=Search%2BForums" class="post-stat-count" title="Recent posts by ${author}" rel="noreferrer">${post_count_stat.querySelector(".post-stat-count").innerText}</a>`;
       }
       // add additional posts actions, skipping admins
       if (add_more_actions == "true" && !post.parentNode.classList.contains("post-admin")) {
@@ -798,37 +618,71 @@ function morePostActions(posts, add_more_actions, forum_search_link) {
         dragon = dragon[dragon.length-1].replace("p.png","")
         avvie.setAttribute("data-stat","avatar-dragon");
         den.setAttribute("data-stat","den");
-        avvie.innerHTML = `<a href="https://${window.location.hostname}/dragon/${dragon}" title="Avatar Dragon"><img src="/static/cms/icons/171.png"></a>`;
-        den.innerHTML = `<a href="${den_link}" title="Hibernal Den"><img src="/static/cms/icons/10.png"></a>`;
+        avvie.innerHTML = `<a href="https://${window.location.hostname}/dragon/${dragon}" title="Avatar Dragon" rel="noreferrer"><img src="/static/cms/icons/171.png"></a>`;
+        den.innerHTML = `<a href="${den_link}" title="Hibernal Den" rel="noreferrer"><img src="/static/cms/icons/10.png"></a>`;
         stats.append(avvie,den);
       }
     }
   })
 }
 
-// function to wait until an element exists to start doing things
-// FROM: https://stackoverflow.com/a/61511955
-function waitForElement(selector) {
-  console.log(`\t[F&BT] Waiting for '${selector}'...`);
+// ----------------------------------------------- //
+//                 USER NOTES                      //
+// ----------------------------------------------- //
 
-  return new Promise(resolve => {
-      if (document.querySelector(selector)) {
-          return resolve(document.querySelector(selector));
-      }
+function userNotes() {
+  let noteButtonBase = document.createElement("span");
+  noteButtonBase.innerHTML = `<img src="/static/cms/icons/71.png"/>`;
+  noteButtonBase.classList = 'user-note-button tipsy';
+  noteButtonBase.setAttribute("aria-role","button");
+  noteButtonBase.setAttribute("data-tipsy","You don't have a note for this user. Click to add a note.");
 
-      const observer = new MutationObserver(mutations => {
-        // if it aint there we observe until it is
-          if (document.querySelector(selector)) {
-              observer.disconnect();
-              resolve(document.querySelector(selector)); // returns the element for us to do stuff with once it shows up
-          }
+  if (/clan-profile/.test(window.location.href)) {
+    if (document.querySelector('.clan-profile-user-frame')) {
 
-      });
-      observer.observe(document.body, {
-          childList: true,
-          subtree: true
-      });
-  });
+    } else {
+      // must be blocked or have been blocked
+      noteButtonBase.classList.add("absolute");
+      let blocked_msg = document.querySelector("#clan-profile > .common-message"),
+          username = document.querySelector(`.breadcrumbs a[href*="clan-profile"]`).innerText,
+          user_id = document.querySelector(`.breadcrumbs a[href*="clan-profile"]`).href.split("/"),
+          your_note = document.createElement("div");
+      user_id = user_id[user_id.length-1];
+      console.log(`${username} #${user_id}`);
+      blocked_msg.after(your_note);
+      your_note.classList = 'common-message common-message-info common-message-small user-note';
+      your_note.innerHTML = `<b>Your Note for ${username}:</b> <p class="user-note-content"></p>`;
+      your_note.append(noteButtonBase.cloneNode(true));
+      your_note.querySelector(`.user-note-button`).setAttribute("data-tipsy","Click to Edit Note");
+      // load notes, find matching by ID & add the note to the page
+      // update username in data if it doesn't match last known username. tracking because it makes exports more human-readable + also because blocked posts don't link to the clan profile
+      // set up edit button to make a modal that lets you add and save a note about a user.
+    }
+  }
+   else if (window.location.href.match("flightrising.com/forums")) {
+     noteButtonBase.classList.add("not-found");
+     let posts = document.querySelectorAll(".post .post-frame");
+     posts.forEach(post => {
+       if (post.parentNode.classList.contains('blocked-post')) {
+            let userNoteButton = noteButtonBase.cloneNode(true),
+              username = post.querySelector(`.post-text-content > strong`).innerText;
+         userNoteButton.classList.add("absolute");
+         userNoteButton.setAttribute("data-target",username);
+         post.querySelector('.post-author').append(userNoteButton);
+
+       } else if (!(post.querySelector('.post-author-username') == null || post.querySelector(".post-author-actions") == null)) {
+         // not your post or blocked post
+         let userNoteButton = noteButtonBase.cloneNode(true),
+             username = post.querySelector('.post-author-username').innerText,
+             user_id = post.querySelector('.post-author-username').href.split("/");
+         user_id = user_id[user_id.length-1];
+         userNoteButton.setAttribute("data-target",user_id);
+         post.querySelector('.post-author-actions').append(userNoteButton);
+         // find user in usernotes by id
+         // update tipsy value with the note if found and remove not-found class
+       }
+     });
+   }
 }
 
 
@@ -839,11 +693,13 @@ function waitForElement(selector) {
 function firstRun() {
   if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-starred`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-starred`,"[]"); console.log("\t\t\t[F&BT] Created local storage for starred threads")};
   if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-bookmarks`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-bookmarks`,"[]");  console.log("\t\t\t[F&BT] Created local storage for bookmarked threads")};
+  if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-user-notes`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-user-notes`,"[]");  console.log("\t\t\t[F&BT] Created local storage for user notes.")};
   if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-show-authors`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-show-authors`,"true");  console.log("\t\t\t[F&BT] Initialized default value for showing thread authors")};
   if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-star-tracker`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-star-tracker`,"true");  console.log("\t\t\t[F&BT] Initialized default value for tracking starred threads")};
   if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-ping-autofocus`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-ping-autofocus`,"true");  console.log("\t\t\t[F&BT] Initialized default value for quick ping autofocus")};
   if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-more-post-actions`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-more-post-actions`,"true");  console.log("\t\t\t[F&BT] Initialized default value for additional user buttons in forum posts.")};
   if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-forum-search-link`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-forum-search-link`,"true");  console.log("\t\t\t[F&BT] Initialized default value for author forum search link.")};
+  if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-enable-user-notes`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-enable-user-notes`,"true");  console.log("\t\t\t[F&BT] Initialized default value for enabling user notes.")};
   BBCODE_TAG_LIST.forEach(tag => {
     if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-${tag.tag}`) == null) { localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-${tag.tag}`,"true"); console.log(`\t\t\t[F&BT] Initialized default value for ${tag.tag} button`)}
   });
@@ -1074,8 +930,251 @@ function backup(action) {
 
 
 // ----------------------------------------------- //
-//               MODALS N BUTTONS                  //
+//             MODALS/BUTTONS & ETC.               //
 // ----------------------------------------------- //
+
+function appendCSS() {
+  const head = document.head || document.getElementsByTagName('head')[0],
+      style = document.createElement('style');
+    let css = `
+    .clan-profile-user-frame {
+      position: relative;
+    }
+    .bbcode-button {
+      padding: 0;
+      height: 47px;
+      width: 47px;
+      box-sizing: border-box;
+      position: relative;
+      z-index: 5;
+      cursor: pointer;
+    }
+    .bbcode-modal:not(.hide) + .bbcode-button.modal {
+      z-index: 11;
+    }
+    .bbcode-modal:not(.hide) + .bbcode-button.modal::before {
+      content: '';
+      position:fixed;
+      top: 0px;
+      left: 0px;
+      width: 100%;
+      height: 100%;
+      border: none;
+      background: rgba(0,0,0,0.5);
+      outline: none;
+      border: none;
+    }
+    .ui-modal-content {
+      position: relative;
+      border: 0;
+      padding: .5em 1em;
+      background: none;
+      overflow: auto;
+    }
+    .bbcode-modal {
+      position: absolute;
+      width: var(--width, 250px);
+      min-height: 200px;
+      z-index: 101;
+      top: 50px;
+      box-sizing: border-box;
+      left: var(--left, -50%);
+    }
+    .bbcode-modal .ui-widget-content h3:first-child {
+      margin-top: 0;
+    }
+    .bbcode-modal img {
+      vertical-align: middle;
+      border: 1px solid var(--borders, #ccc);
+      margin-left: 0.5em;
+    }
+    .bbcode-modal a {
+      color: var(--link, #731d08)
+    }
+    .check-list, .button-list {
+      display: grid;
+      text-align: left;
+      grid-gap: 0.5em;
+      margin: 0.8em 0 0.5em;
+    }
+    .col-2 {
+      grid-template-columns: 1fr 1fr;
+    }
+    .check-list label {
+      display: grid;
+      grid-template-columns: 25px auto;
+      align-items: center;
+    }
+    .button-list {
+      flex-wrap: wrap;
+    }
+    .threads {
+      margin: 10px 0 10px 5px;
+      max-height: 16em;
+      overflow: auto;
+      padding-right: 0.6em;
+    }
+    .threads li {
+      display: flex;
+      margin-bottom: 0.5em;
+    }
+    .threads li::before {
+      content: '•' / '';
+      margin-right: 5px;
+    }
+    .threads li i {
+      margin-left: auto;
+    }
+    .threads li > a, .threads li > i {
+      text-overflow: ellipsis;
+      display: inline-block;
+      overflow-x: hidden;
+      white-space: pre;
+      line-height: 1.3em;
+      max-width: 100%;
+    }
+    .threads.show-authors li > a {
+      max-width: 70%;
+    }
+    .threads.show-authors li > i {
+      max-width: 30%;
+    }
+    button.rmv-setting {
+      padding: 0.5em !important;
+      width: 100%;
+    }
+    .rmv-bookmark {
+      margin-left: auto;
+      color: rgba(var(--error, 150, 0, 0),0.3);
+      background: none;
+      border: none;
+      position: relative;
+      cursor: pointer;
+      font-weight: bold;
+      transition: 0.3s color;
+    }
+    .rmv-bookmark:hover {
+      color: rgba(var(--error, 150, 0, 0),1);
+    }
+    .rmv-bookmark.tipsy::after {
+      font-weight: normal;
+      left: unset;
+      right: 1em;
+      top: -0.3em;
+      min-width: 25px;
+    }
+    .threads.show-authors li > i + .rmv-bookmark {
+      margin-left: 0.4em
+    }
+    #backup-zone #data {
+      grid-column: 1 / 3;
+      resize: none;
+      height: 150px;
+      width: 100%;
+      font-size: 10px;
+      font-family: monospace;
+    }
+    .expand-setting {
+      cursor: pointer;
+      background: none;
+      border: none;
+      color: inherit;
+      font: inherit;
+      display: inline-flex;
+      justify-content: space-between;
+      width: 100%;
+    }
+    .expand-setting span {
+      margin-left: auto;
+    }
+    .expand {
+      max-height: 0px;
+      overflow: hidden;
+      transition: max-height 0.3s, opacity: 0.3s;
+    }
+    .expand.expanded {
+      max-height:500px;
+      opacity: 1;
+    }
+    .expander :is(.on,.off) {
+      pointer-events: none;
+    }
+    .user-note-button {
+      position: relative;
+      cursor: pointer;
+      z-index: 2;
+      flex-grow: 1;
+    }
+    .user-note-button img {
+      display: block;
+      margin: 0 auto;
+    }
+    .user-note-button.absolute {
+      position: absolute;
+      top: 0.4rem;
+      right: 0.4rem;
+    }
+    .user-note-button.not-found img {
+      filter: grayscale(100%);
+    }
+    p.user-note-content {
+      padding: 1em;
+    }
+    .user-note-content:empty::after {
+      content: 'You do not have a note for this user.';
+      font-style: italic;
+    }
+    .common-message-info.user-note {
+      background-image: url('/static/layout/clan-profile/bio-background.png');
+      background-size: 150px;
+      background-position: 0px 15%;
+      position: relative;
+    }
+    div.post-author { z-index: 2; }
+    .post-action-quick-ping.tipsy::after { top: calc(100% + 6px); left: calc(50% - 40px); }
+    .post-action-quick-ping:hover::after, .post-action-quick-ping:focus::after { display: block; }
+    .thread-locked { pointer-events: none !important; user-select: none; opacity: 0.5; }
+    .user-note-button.tipsy::after { top: unset; bottom: 115%; }
+    .tipsy::after {
+      content: attr(data-tipsy); min-width: 150px; max-width: 300px; height: auto; line-height: 120%;
+      font-size: 1rem; color: var(--text, #000); background: var(--tooltip-bg, #fff); border-radius: 10px;
+      font-size: inherit; position: absolute; border:1px solid var(--borders, #888);box-shadow:rgba(0, 0, 0, 0.5) 1px 1px 6px;
+      top: 112%; left: calc(50% - 100px); padding: 8px; box-sizing: border-box; z-index: 2;right:unset;bottom:unset;
+      text-align: left;
+      display: none;
+    }
+    .tipsy:hover::after { display: block !important; }
+    .bbcode-modal:not(.hide) + .bbcode-button.modal::after { display: none !important; }
+    .threads:empty::before { content: "No threads found."; display: block; font-style: italic; margin-bottom: 1.2em; }
+    .toggled[data-toggled="0"] .on { display: none; }
+    .toggled[data-toggled="1"] .off { display: none; }
+    .hide {
+      display: none !important;
+    }
+    `;
+    if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-more-post-actions`) == "true") {
+      css += `
+      .post-frame {
+        min-height: 330px;
+      }`;
+    }
+  if (localStorage.getItem(`${LOCAL_STORAGE_PREFIX}-enable-user-notes`) == "true") {
+      css += `
+      .post-author-action {
+        width: auto;
+        flex-grow: 1;
+      }
+      .post-author-actions {
+        display: flex;
+        flex-wrap: wrap;
+      }`;
+    }
+
+    head.appendChild(style);
+    style.type = 'text/css';
+    style.id = `${LOCAL_STORAGE_PREFIX}-style`;
+    style.appendChild(document.createTextNode(css));
+}
 
 function createForumControlsModal(name, title, content, style = "") {
   var modal = document.createElement("div");
@@ -1131,7 +1230,7 @@ function createForumToggleButton(name, tooltip, image, toggled_tooltip, toggle_i
 
   btn.innerHTML = `<img src="${image}" role="button" alt="${name} button" class="off"><img src="${toggle_image}" role="button" alt="${name} button" class="on">`;
   btn.addEventListener("click", function(event) {
-    console.log("clicked ${name}");
+    console.log(`clicked ${name}`);
     if (btn.getAttribute("data-toggled") == "0") {
       btn.setAttribute("data-toggled", "1");
       btn.setAttribute("data-tipsy", btn.getAttribute("data-tipsy-1"));
@@ -1141,6 +1240,31 @@ function createForumToggleButton(name, tooltip, image, toggled_tooltip, toggle_i
     }
   });
   return btn;
+}
+
+// function to wait until an element exists to start doing things
+// FROM: https://stackoverflow.com/a/61511955
+function waitForElement(selector) {
+  console.log(`\t[F&BT] Waiting for '${selector}'...`);
+
+  return new Promise(resolve => {
+      if (document.querySelector(selector)) {
+          return resolve(document.querySelector(selector));
+      }
+
+      const observer = new MutationObserver(mutations => {
+        // if it aint there we observe until it is
+          if (document.querySelector(selector)) {
+              observer.disconnect();
+              resolve(document.querySelector(selector)); // returns the element for us to do stuff with once it shows up
+          }
+
+      });
+      observer.observe(document.body, {
+          childList: true,
+          subtree: true
+      });
+  });
 }
 
 FBTinit();

--- a/scripts/theme-quickswitcher.user.js
+++ b/scripts/theme-quickswitcher.user.js
@@ -1,0 +1,44 @@
+// ==UserScript==
+// @name        Flight Rising: Theme Quickswitcher
+// @namespace   https://github.com/dragonjpg
+// @author      dragon.jpg
+// @version     1.0.0
+// @match       https://*.flightrising.com/*
+// @grant       none
+// @license     MIT
+// @icon        https://www.google.com/s2/favicons?sz=64&domain=flightrising.com
+// @description Adds a button to quickly toggle between two themes of your choice. Made so you can make the most of my Simple Themes userstyle. keeps track of your active theme and overwrites the data-theme value the site serves on pageload. advice: keep dark mode as your selected theme in account settings because there may be a flash of content before themes switch, and dark to light is easier on the eyes than light to dark.
+// ==/UserScript==
+
+// CHANGE THESE TO SWAP BETWEEN DIFFERENT THEMES
+const DAY = 'default',
+      NIGHT = 'dark';
+
+// DO NOT TOUCH BELOW
+const NIGHT_SVG = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 22C17.5228 22 22 17.5228 22 12C22 11.5373 21.3065 11.4608 21.0672 11.8568C19.9289 13.7406 17.8615 15 15.5 15C11.9101 15 9 12.0899 9 8.5C9 6.13845 10.2594 4.07105 12.1432 2.93276C12.5392 2.69347 12.4627 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" class="theme-svg-player-module-logout-glyph-fill"/></svg>`,
+      DAY_SVG = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M17 12C17 14.7614 14.7614 17 12 17C9.23858 17 7 14.7614 7 12C7 9.23858 9.23858 7 12 7C14.7614 7 17 9.23858 17 12Z" class="theme-svg-player-module-logout-glyph-fill"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12 1.25C12.4142 1.25 12.75 1.58579 12.75 2V4C12.75 4.41421 12.4142 4.75 12 4.75C11.5858 4.75 11.25 4.41421 11.25 4V2C11.25 1.58579 11.5858 1.25 12 1.25ZM3.66865 3.71609C3.94815 3.41039 4.42255 3.38915 4.72825 3.66865L6.95026 5.70024C7.25596 5.97974 7.2772 6.45413 6.9977 6.75983C6.7182 7.06553 6.2438 7.08677 5.9381 6.80727L3.71609 4.77569C3.41039 4.49619 3.38915 4.02179 3.66865 3.71609ZM20.3314 3.71609C20.6109 4.02179 20.5896 4.49619 20.2839 4.77569L18.0619 6.80727C17.7562 7.08677 17.2818 7.06553 17.0023 6.75983C16.7228 6.45413 16.744 5.97974 17.0497 5.70024L19.2718 3.66865C19.5775 3.38915 20.0518 3.41039 20.3314 3.71609ZM1.25 12C1.25 11.5858 1.58579 11.25 2 11.25H4C4.41421 11.25 4.75 11.5858 4.75 12C4.75 12.4142 4.41421 12.75 4 12.75H2C1.58579 12.75 1.25 12.4142 1.25 12ZM19.25 12C19.25 11.5858 19.5858 11.25 20 11.25H22C22.4142 11.25 22.75 11.5858 22.75 12C22.75 12.4142 22.4142 12.75 22 12.75H20C19.5858 12.75 19.25 12.4142 19.25 12ZM17.0255 17.0252C17.3184 16.7323 17.7933 16.7323 18.0862 17.0252L20.3082 19.2475C20.6011 19.5404 20.601 20.0153 20.3081 20.3082C20.0152 20.6011 19.5403 20.601 19.2475 20.3081L17.0255 18.0858C16.7326 17.7929 16.7326 17.3181 17.0255 17.0252ZM6.97467 17.0253C7.26756 17.3182 7.26756 17.7931 6.97467 18.086L4.75244 20.3082C4.45955 20.6011 3.98468 20.6011 3.69178 20.3082C3.39889 20.0153 3.39889 19.5404 3.69178 19.2476L5.91401 17.0253C6.2069 16.7324 6.68177 16.7324 6.97467 17.0253ZM12 19.25C12.4142 19.25 12.75 19.5858 12.75 20V22C12.75 22.4142 12.4142 22.75 12 22.75C11.5858 22.75 11.25 22.4142 11.25 22V20C11.25 19.5858 11.5858 19.25 12 19.25Z" class="theme-svg-player-module-logout-glyph-fill"/></svg>`;
+
+(function() {
+  if(document.querySelector(`#fr-layout`) != null) {
+    document.querySelector(`#fr-layout`).setAttribute('data-theme',localStorage.getItem(`fr-active-theme`));
+    if(localStorage.getItem(`fr-active-theme`)  == null) {
+      localStorage.setItem(`fr-active-theme`, document.querySelector(`#fr-layout`).getAttribute('data-theme'));
+    };
+    let toggler = document.createElement(`div`);
+    let togglerCSS = document.createElement(`style`);
+    togglerCSS.type = `text/css`;
+    togglerCSS.appendChild(document.createTextNode(`#themeswap { position: absolute; top: 8px; right: 36px; width: 20px; height: 20px; cursor: pointer; border: none; background: none; z-index: 4; } .fr-theme[data-theme="${DAY}"] .night { display: none } .fr-theme[data-theme="${NIGHT}"] .day { display: none }`));
+    toggler.innerHTML = `<button id="themeswap" data-theme="${localStorage.getItem(`fr-active-theme`)}" title="Toggle Theme"><span class="day">${DAY_SVG}</span><span class="night">${NIGHT_SVG}</span></button>`;
+    document.querySelector(`#fr-layout-player-module-logout`).before(toggler);
+    toggler.before(togglerCSS);
+    toggler.addEventListener('click',function() {
+      if (localStorage.getItem(`fr-active-theme`) == DAY) {
+        localStorage.setItem( `fr-active-theme`,NIGHT);
+        document.querySelector(`#fr-layout`).setAttribute('data-theme',NIGHT);
+      } else {
+        localStorage.setItem( `fr-active-theme`,DAY);
+        document.querySelector(`#fr-layout`).setAttribute('data-theme',DAY);
+      }
+    })
+  }
+})();


### PR DESCRIPTION
- Fixed Breeding Lock & Forum & BBCode Tweaks being broken by the revamp's changes to class names.
- Added a new Theme Quick Switcher Script as a companion to Simple Themes (prev. Simple Dark Redux), allowing you to quickly switch between light and dark themes without going into your account settings every single time.